### PR TITLE
Fixes Image Generation App crash

### DIFF
--- a/codelabs/image_generation_basic/android/finish/app/src/main/java/com/google/mediapipe/examples/imagegeneration/MainViewModel.kt
+++ b/codelabs/image_generation_basic/android/finish/app/src/main/java/com/google/mediapipe/examples/imagegeneration/MainViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.io.File
 
 class MainViewModel : ViewModel() {
     private val _uiState = MutableStateFlow(UiState())
@@ -59,10 +60,18 @@ class MainViewModel : ViewModel() {
                 return
             }
 
-            _uiState.update { it.copy(isInitializing = true) }
             val mainLooper = Looper.getMainLooper()
             GlobalScope.launch {
+                if (!File(MODEL_PATH).exists()) {
+                    _uiState.update {
+                        it.copy(
+                            error = "Can't find ML model",
+                        )
+                    }
+                    return@launch
+                }
                 val startTime = System.currentTimeMillis()
+                _uiState.update { it.copy(isInitializing = true) }
                 helper?.initializeImageGenerator(MODEL_PATH)
                 Handler(mainLooper).post {
                     _uiState.update {
@@ -74,7 +83,6 @@ class MainViewModel : ViewModel() {
                     }
                 }
             }
-
         } catch (e: Exception) {
             _uiState.update {
                 it.copy(

--- a/codelabs/image_generation_basic/android/start/app/src/main/java/com/google/mediapipe/examples/imagegeneration/MainViewModel.kt
+++ b/codelabs/image_generation_basic/android/start/app/src/main/java/com/google/mediapipe/examples/imagegeneration/MainViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.io.File
 
 class MainViewModel : ViewModel() {
     private val _uiState = MutableStateFlow(UiState())
@@ -58,11 +59,18 @@ class MainViewModel : ViewModel() {
                 _uiState.update { it.copy(error = "Display iteration cannot be empty") }
                 return
             }
-
-            _uiState.update { it.copy(isInitializing = true) }
             val mainLooper = Looper.getMainLooper()
             GlobalScope.launch {
+                if (!File(MODEL_PATH).exists()) {
+                    _uiState.update {
+                        it.copy(
+                            error = "Can't find ML model",
+                        )
+                    }
+                    return@launch
+                }
                 val startTime = System.currentTimeMillis()
+                _uiState.update { it.copy(isInitializing = true) }
                 helper?.initializeImageGenerator(MODEL_PATH)
                 Handler(mainLooper).post {
                     _uiState.update {
@@ -74,7 +82,6 @@ class MainViewModel : ViewModel() {
                     }
                 }
             }
-
         } catch (e: Exception) {
             _uiState.update {
                 it.copy(


### PR DESCRIPTION
In the final step on the codelab here:
https://codelabs.developers.google.com/mp-image-generation-basic-android#3
we have:
```
// Step 6 - set model path
private val MODEL_PATH = "/data/local/tmp/image_generator/bins/"
```
After you set this up and finishing other steps when you run the app, the app crashes as soon as we try to initialize the interpreter because the app can't find the model in that path. The backtrace of the error is:

```
2024-05-26 18:21:33.435  7456-7600  AndroidRuntime          pid-7456                             E  FATAL EXCEPTION: DefaultDispatcher-worker-1
                                                                                                    Process: com.google.mediapipe.examples.imagegeneration, PID: 7456
                                                                                                    com.google.mediapipe.framework.MediaPipeException: not found: CalculatorGraph::Run() failed: 
                                                                                                    Calculator::Open() for node "mediapipe_tasks_vision_image_generator_imagegeneratorgraph__StableDiffusionIterateCalculator" failed: The path does not exist: /data/local/tmp/image_generator/bins/; /data/local/tmp/image_generator/bins/
                                                                                                    	at com.google.mediapipe.framework.Graph.nativeWaitUntilGraphIdle(Native Method)
                                                                                                    	at com.google.mediapipe.framework.Graph.waitUntilGraphIdle(Graph.java:471)
                                                                                                    	at com.google.mediapipe.tasks.core.TaskRunner.create(TaskRunner.java:74)
                                                                                                    	at com.google.mediapipe.tasks.vision.imagegenerator.ImageGenerator.createFromOptions(ImageGenerator.java:167)
                                                                                                    	at com.google.mediapipe.tasks.vision.imagegenerator.ImageGenerator.createFromOptions(ImageGenerator.java:96)
                                                                                                    	at com.google.mediapipe.examples.imagegeneration.ImageGenerationHelper.initializeImageGenerator(ImageGenerationHelper.kt:31)
                                                                                                    	at com.google.mediapipe.examples.imagegeneration.MainViewModel$initializeImageGenerator$3.invokeSuspend(MainViewModel.kt:66)
                                                                                                    	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
                                                                                                    	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
                                                                                                    	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
                                                                                                    	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
                                                                                                    	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
                                                                                                    	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
                                                                                                    	Suppressed: kotlinx.coroutines.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@6d40853, Dispatchers.Default]
```

I couldn't find the model in any other path on internal storage of the app, also as far as I researched the app or the user can't access any files in `/data/` dir if the phone is not rooted. What I did here is just handled this case so the app doesn't crash but shows the toast message.
I am using this to also ask a question about the model, since I couldn't find anything on the codelab, so is the model in different path or should we push it to the device manually ?
Thank you!



Update:
I just saw that this is mentioned at the end of the page, and gives the steps how to generate the model and push it to the device, but maybe we can leave the toast message here ?