### PR TITLE
Update CameraFragment.kt

### DIFF
--- a/examples/object_detection/android/app/src/main/java/com/google/mediapipe/examples/objectdetection/fragments/CameraFragment.kt
+++ b/examples/object_detection/android/app/src/main/java/com/google/mediapipe/examples/objectdetection/fragments/CameraFragment.kt
@@ -232,7 +232,7 @@ class CameraFragment : Fragment(), ObjectDetectorHelper.DetectorListener {
                     p3: Long
                 ) {
                     try {
-                        objectDetectorHelper.currentDelegate = p2
+                        objectDetectorHelper.currentModel = p2
                         updateControlsUi()
                     } catch(e: UninitializedPropertyAccessException) {
                         Log.e(TAG, "ObjectDetectorHelper has not been initialized yet.")


### PR DESCRIPTION
### Description
the fix was to update the `onItemSelectedListener` for **spinnerModel**. Instead of setting `objectDetectorHelper.currentDelegate`, we now directly set `objectDetectorHelper.currentModel = p2`. This ensures that when a new model is selected, the `objectDetectorHelper` actually uses the correct model for predictions, resolving the issue where results weren't updating.

### Checklist
Please ensure the following items are complete before submitting a pull request:

- [x] My code follows the code style of the project.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added tests to cover my changes.

### Type of Change
Please check the relevant option below:

- [x] Bug fix (non-breaking change which fixes an issue)

### Additional Notes
This change is straightforward and should not impact any other functionality. Additional tests for model switching behavior would be beneficial but are not included in this pull request.
