### PR TITLE
Fix import in background_segmenter tutorial

### DIFF
--- a/tutorials/background_segmenter/code/index.js
+++ b/tutorials/background_segmenter/code/index.js
@@ -1,5 +1,5 @@
 // we start by importing mediapipe tasks vision module
-import vision from "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision";
+import * as vision from "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision";
 
 // we then import the camera class and the utils functions
 import Camera from "./camera.js";


### PR DESCRIPTION
### Description
Fix an error in the background_segmenter tutorial
Uncaught SyntaxError: The requested module 'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision' does not provide an export named 'default' (at index.js:2:8)

Fixes # (issue)

### Checklist
Please ensure the following items are complete before submitting a pull request:

- [x ] My code follows the code style of the project.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added tests to cover my changes.

### Type of Change
Please check the relevant option below:

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update (non-breaking change which updates documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots
If applicable, please add screenshots to help explain your changes.

### Additional Notes
Add any additional information or context about the pull request here.
