### PR TITLE
use com.halilibo.richtext for Markdown rendering

### DIFF
--- a/examples/llm_inference/android/app/build.gradle.kts
+++ b/examples/llm_inference/android/app/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     implementation("androidx.compose.material3:material3")
 
     implementation ("com.google.mediapipe:tasks-genai:0.10.16")
+    implementation "com.github.jeziellago:compose-markdown:0.3.6"
 
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/examples/llm_inference/android/app/src/main/java/com/google/mediapipe/examples/llminference/ChatScreen.kt
+++ b/examples/llm_inference/android/app/src/main/java/com/google/mediapipe/examples/llminference/ChatScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.variable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -37,6 +37,9 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+
+import com.halilibo.richtext.markdown.Markdown
+import com.halilibo.richtext.ui.material3.Material3RichText
 
 @Composable
 internal fun ChatRoute(
@@ -178,10 +181,13 @@ fun ChatItem(
                             modifier = Modifier.padding(16.dp)
                         )
                     } else {
-                        Text(
-                            text = chatMessage.message,
+                        Material3RichText(
                             modifier = Modifier.padding(16.dp)
-                        )
+                        ) {
+                            Markdown(
+                                content = chatMessage.message
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
In LLM Inference Android example, use Markdown rendering for chat messages.

Have not yet tested - requesting review from @bebechien.