### PR TITLE
Use access token when download model from HuggingFace

### DIFF
--- a/examples/llm_inference/android/app/build.gradle.kts
+++ b/examples/llm_inference/android/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
@@ -18,6 +20,19 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+
+        // Define the BuildConfig field
+        val properties = Properties()
+        val localPropertiesFile = rootProject.file("local.properties")
+        if (localPropertiesFile.exists()) {
+            localPropertiesFile.inputStream().use { properties.load(it) }
+        }
+        val hfAccessToken = properties.getProperty("HF_ACCESS_TOKEN", "")
+        buildConfigField("String", "HF_ACCESS_TOKEN", "\"$hfAccessToken\"")
+    }
+
+    buildFeatures {
+        buildConfig = true
     }
 
     buildTypes {

--- a/examples/llm_inference/android/app/src/main/java/com/google/mediapipe/examples/llminference/LoadingScreen.kt
+++ b/examples/llm_inference/android/app/src/main/java/com/google/mediapipe/examples/llminference/LoadingScreen.kt
@@ -83,7 +83,7 @@ private fun downloadModel(context: Context, model: Model, client: OkHttpClient, 
     val outputFile = File(context.filesDir, File(InferenceModel.model.path).name)
     val requestBuilder = Request.Builder().url(model.url)
 
-    if (model.needAuth && model.url.startsWith("https://huggingface.co/")) {
+    if (model.needsAuth && model.url.startsWith("https://huggingface.co/")) {
         val hfAccessToken = BuildConfig.HF_ACCESS_TOKEN
         if (hfAccessToken.isEmpty()) {
             throw MissingAccessTokenException()

--- a/examples/llm_inference/android/app/src/main/java/com/google/mediapipe/examples/llminference/LoadingScreen.kt
+++ b/examples/llm_inference/android/app/src/main/java/com/google/mediapipe/examples/llminference/LoadingScreen.kt
@@ -71,8 +71,7 @@ internal fun LoadingRoute(
                 }
             } catch (e: MissingAccessTokenException) {
                 errorMessage = e.localizedMessage ?: "Unknown Error"
-            }
-            catch (e: Exception) {
+            } catch (e: Exception) {
                 val error = e.localizedMessage ?: "Unknown Error"
                 errorMessage = "${error}, please copy the model manually to ${InferenceModel.model.path}"
             }

--- a/examples/llm_inference/android/app/src/main/java/com/google/mediapipe/examples/llminference/LoadingScreen.kt
+++ b/examples/llm_inference/android/app/src/main/java/com/google/mediapipe/examples/llminference/LoadingScreen.kt
@@ -76,8 +76,14 @@ internal fun LoadingRoute(
 
 private fun downloadModel(context: Context, model: Model, client: OkHttpClient, onProgressUpdate: (Int) -> Unit) {
     val outputFile = File(context.filesDir, File(InferenceModel.model.path).name)
-    val request = Request.Builder().url(model.url).build()
-    val response = client.newCall(request).execute()
+    val requestBuilder = Request.Builder().url(model.url)
+
+    val hfAccessToken = BuildConfig.HF_ACCESS_TOKEN
+    if (model.url.startsWith("https://huggingface.co/") && !hfAccessToken.isEmpty()) {
+        requestBuilder.addHeader("Authorization", "Bearer $hfAccessToken")
+    }
+
+    val response = client.newCall(requestBuilder.build()).execute()
     if (!response.isSuccessful) throw Exception("Download failed: ${response.code}")
 
     response.body?.byteStream()?.use { inputStream ->

--- a/examples/llm_inference/android/app/src/main/java/com/google/mediapipe/examples/llminference/Model.kt
+++ b/examples/llm_inference/android/app/src/main/java/com/google/mediapipe/examples/llminference/Model.kt
@@ -2,8 +2,40 @@ package com.google.mediapipe.examples.llminference
 
 // NB: Make sure the filename is *unique* per model you use!
 // Weight caching is currently based on filename alone.
-enum class Model(val path: String, val url: String, val uiState: UiState, val temperature: Float, val topK: Int, val topP: Float) {
-    GEMMA_CPU("/data/local/tmp/llm/gemma-2b-it-cpu-int4.bin", "", GemmaUiState(), temperature = 0.8f, topK = 40, topP = 1.0f),
-    GEMMA_GPU("/data/local/tmp/llm/gemma-2b-it-gpu-int4.bin", "", GemmaUiState(), temperature = 0.8f, topK = 40, topP = 1.0f),
-    DEEPSEEK_CPU("/data/local/tmp/llm/deepseek3k_q8_ekv1280.task","", DeepSeeUiState(), temperature = 0.6f, topK = 40, topP = 0.7f),
+enum class Model(
+    val path: String,
+    val url: String,
+    val needAuth: Boolean,
+    val uiState: UiState,
+    val temperature: Float,
+    val topK: Int,
+    val topP: Float,
+) {
+    GEMMA_CPU(
+        path = "/data/local/tmp/llm/gemma-2b-it-cpu-int4.bin",
+        url = "",
+        needAuth = false,
+        GemmaUiState(),
+        temperature = 0.8f,
+        topK = 40,
+        topP = 1.0f
+    ),
+    GEMMA_GPU(
+        path = "/data/local/tmp/llm/gemma-2b-it-gpu-int4.bin",
+        url = "",
+        needAuth = false,
+        GemmaUiState(),
+        temperature = 0.8f,
+        topK = 40,
+        topP = 1.0f
+    ),
+    DEEPSEEK_CPU(
+        path = "/data/local/tmp/llm/deepseek3k_q8_ekv1280.task",
+        url = "",
+        needAuth = false,
+        DeepSeeUiState(),
+        temperature = 0.6f,
+        topK = 40,
+        topP = 0.7f
+    ),
 }

--- a/examples/llm_inference/android/app/src/main/java/com/google/mediapipe/examples/llminference/Model.kt
+++ b/examples/llm_inference/android/app/src/main/java/com/google/mediapipe/examples/llminference/Model.kt
@@ -5,7 +5,7 @@ package com.google.mediapipe.examples.llminference
 enum class Model(
     val path: String,
     val url: String,
-    val needAuth: Boolean,
+    val needsAuth: Boolean,
     val uiState: UiState,
     val temperature: Float,
     val topK: Int,
@@ -14,7 +14,7 @@ enum class Model(
     GEMMA_CPU(
         path = "/data/local/tmp/llm/gemma-2b-it-cpu-int4.bin",
         url = "",
-        needAuth = false,
+        needsAuth = true,
         GemmaUiState(),
         temperature = 0.8f,
         topK = 40,
@@ -23,7 +23,7 @@ enum class Model(
     GEMMA_GPU(
         path = "/data/local/tmp/llm/gemma-2b-it-gpu-int4.bin",
         url = "",
-        needAuth = false,
+        needsAuth = true,
         GemmaUiState(),
         temperature = 0.8f,
         topK = 40,
@@ -32,7 +32,7 @@ enum class Model(
     DEEPSEEK_CPU(
         path = "/data/local/tmp/llm/deepseek3k_q8_ekv1280.task",
         url = "",
-        needAuth = false,
+        needsAuth = false,
         DeepSeeUiState(),
         temperature = 0.6f,
         topK = 40,

--- a/examples/llm_inference/android/gradle.properties
+++ b/examples/llm_inference/android/gradle.properties
@@ -22,4 +22,6 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 
+# Hugging Face access token, used to access Hugging Face models which need
+# authentication.
 HF_ACCESS_TOKEN=${HF_ACCESS_TOKEN}

--- a/examples/llm_inference/android/gradle.properties
+++ b/examples/llm_inference/android/gradle.properties
@@ -21,3 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+HF_ACCESS_TOKEN=${HF_ACCESS_TOKEN}


### PR DESCRIPTION
When user needs to download model from  HuggingFace which needs authentication, follow these steps:

1. Create a HuggingFace access token by following https://huggingface.co/docs/huggingface_hub/quick-start#authentication.

3. Add below line in `local.properties` (Do NOT commit local.properties to version control, which is already added in .gitignore).

```
HF_ACCESS_TOKEN=your_huggingface_token
```

4. Sync Gradle and build your app.
