### PR TITLE
Fix ChatScreen crash when switch model.

### DIFF
--- a/examples/llm_inference/android/app/src/main/java/com/google/mediapipe/examples/llminference/ChatScreen.kt
+++ b/examples/llm_inference/android/app/src/main/java/com/google/mediapipe/examples/llminference/ChatScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -38,8 +39,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.viewmodel.compose.viewModel
 
 @Composable
@@ -48,6 +47,12 @@ internal fun ChatRoute(
 ) {
     val context = LocalContext.current.applicationContext
     val chatViewModel: ChatViewModel = viewModel(factory = ChatViewModel.getFactory(context))
+
+    // Reset InferenceModel when entering ChatScreen
+    LaunchedEffect(Unit) {
+        val inferenceModel = InferenceModel.getInstance(context)
+        chatViewModel.resetInferenceModel(inferenceModel)
+    }
 
     val uiState by chatViewModel.uiState.collectAsStateWithLifecycle()
     val textInputEnabled by chatViewModel.isTextInputEnabled.collectAsStateWithLifecycle()

--- a/examples/llm_inference/android/app/src/main/java/com/google/mediapipe/examples/llminference/ChatViewModel.kt
+++ b/examples/llm_inference/android/app/src/main/java/com/google/mediapipe/examples/llminference/ChatViewModel.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.collectIndexed
 import kotlinx.coroutines.launch
 
 class ChatViewModel(
-    private val inferenceModel: InferenceModel
+    private var inferenceModel: InferenceModel
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<UiState> = MutableStateFlow(inferenceModel.uiState)
@@ -24,6 +24,11 @@ class ChatViewModel(
         MutableStateFlow(true)
     val isTextInputEnabled: StateFlow<Boolean> =
         _textInputEnabled.asStateFlow()
+
+    fun resetInferenceModel(newModel: InferenceModel) {
+        inferenceModel = newModel
+        _uiState.value = inferenceModel.uiState
+    }
 
     fun sendMessage(userMessage: String) {
         viewModelScope.launch(Dispatchers.IO) {


### PR DESCRIPTION
In https://github.com/google-ai-edge/mediapipe-samples/pull/523, to share the ChatViewModel (e.g. send button enable status) during ChatRoute recomposition, ChatViewModel instance is reused.

However the InferenceModel in ChatViewModel is not reset when switching model, which caused the app crashed.

Now fixing this crash issue by reseting InferenceModel when entering ChatScreen.