### PR TITLE
fix: use correct UI state for Gemma models

### DIFF
--- a/examples/llm_inference/android/app/src/main/java/com/google/mediapipe/examples/llminference/Model.kt
+++ b/examples/llm_inference/android/app/src/main/java/com/google/mediapipe/examples/llminference/Model.kt
@@ -22,7 +22,7 @@ enum class Model(
         licenseUrl = "https://huggingface.co/litert-community/Gemma3-1B-IT",
         needsAuth = true,
         preferredBackend = Backend.CPU,
-        uiState = GenericUiState(),
+        uiState = GemmaUiState(),
         temperature = 1f,
         topK = 64,
         topP = 0.95f
@@ -33,7 +33,7 @@ enum class Model(
         licenseUrl = "https://huggingface.co/litert-community/Gemma3-1B-IT",
         needsAuth = true,
         preferredBackend = Backend.GPU,
-        uiState = GenericUiState(),
+        uiState = GemmaUiState(),
         temperature = 1f,
         topK = 64,
         topP = 0.95f


### PR DESCRIPTION
### Description
Fixes an issue where incorrect UI state was being used for Gemma models, which caused it to use the wrong turn markers to structure the conversation.

### Checklist

- [x] My code follows the code style of the project.
- [ ] I have updated the documentation (not applicable).
- [ ] I have added tests to cover my changes.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update (non-breaking change which updates documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
