### PR TITLE
Allow offline cached model usage

### DIFF
--- a/examples/llm_inference/llm_chat_ts/src/llm_service.ts
+++ b/examples/llm_inference/llm_chat_ts/src/llm_service.ts
@@ -20,7 +20,7 @@ import { produce } from 'immer';
 import { ChatMessage, Persona, Tool } from './types';
 import { BASE_GEMMA3_PERSONA } from './personas/base_gemma3';
 import { streamWithProgress } from './streaming_utils';
-import { loadModelWithCache } from './opfs_cache';
+import { getOauthToken, loadModelWithCache } from './opfs_cache';
 
 export const MODEL_PATHS = [
   [
@@ -95,6 +95,7 @@ export class LlmService {
     this.genaiFileset = FilesetResolver.forGenAiTasks(
       "wasm"
     );
+    getOauthToken();
   }
 
   isInitialized(): boolean {


### PR DESCRIPTION
### Description
Allow offline cached model usage. Also revoke stored oauth upon failed remote fetch, and cause llm service to update oauth at least once.
