### PR TITLE
Fix a small oauth bug and update UI indicators for cached models

### DIFF
--- a/examples/llm_inference/llm_chat_ts/src/llm_options.ts
+++ b/examples/llm_inference/llm_chat_ts/src/llm_options.ts
@@ -38,12 +38,12 @@ export class LlmOptions extends LitElement {
   @property({ type: String })
   selectedPersonaName: string = PERSONAS[0]?.name ?? '';
 
+  @property({ type: Array })
+  cachedModels: Set<string> = new Set<string>();
+
   @state()
   private options: LlmInferenceOptions & { forceF32?: boolean } =
     structuredClone(DEFAULT_OPTIONS);
-
-  @state()
-  private cachedModels = new Set<string>();
 
   @state()
   private isLoggedIn = !!localStorage.getItem('oauth');

--- a/examples/llm_inference/llm_chat_ts/src/opfs_cache.ts
+++ b/examples/llm_inference/llm_chat_ts/src/opfs_cache.ts
@@ -64,8 +64,6 @@ export async function getOauthToken(): Promise<OAuthToken | null> {
 export async function loadModelWithCache(modelPath: string): Promise<{ stream: ReadableStream<Uint8Array>, size: number }> {
   const fileName = getFileName(modelPath);
   const opfsRoot = await navigator.storage.getDirectory();
-  const oauthToken = await getOauthToken();
-  const headers = oauthToken ? { "Authorization": `Bearer ${oauthToken.accessToken}` } : undefined;
 
   // 1. Check for and validate the cached file
   try {
@@ -93,6 +91,9 @@ export async function loadModelWithCache(modelPath: string): Promise<{ stream: R
         console.error('Error accessing OPFS:', e);
     }
   }
+
+  const oauthToken = await getOauthToken();
+  const headers = oauthToken ? { "Authorization": `Bearer ${oauthToken.accessToken}` } : undefined;
 
   // 2. If model was missing or invalid in cache, first fetch the size from headers.
   let expectedSize = -1;


### PR DESCRIPTION
### Description
If certain errors in oauth token fetching were thrown, this could cause offline models to break, so those calls should come after cache checks. Also, "cached" indicators were not being updated, so made them reactive properties and have them update/refresh whenever we finish trying to load a model (either successfully or unsuccessfully).

Fixes # (issue)

### Checklist
Please ensure the following items are complete before submitting a pull request:

- [ ] My code follows the code style of the project.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added tests to cover my changes.

### Type of Change
Please check the relevant option below:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update (non-breaking change which updates documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots
If applicable, please add screenshots to help explain your changes.

### Additional Notes
Add any additional information or context about the pull request here.
