### PR TITLE
web gemma3 demo: fix stale UI for cache token and calculations

### DIFF
--- a/examples/llm_inference/llm_chat_ts/src/llm_chat.ts
+++ b/examples/llm_inference/llm_chat_ts/src/llm_chat.ts
@@ -499,10 +499,15 @@ export class LlmChat extends LitElement {
           .cachedModels=${this.cachedModels}
           @options-changed=${this.handleOptionsChange}
           @persona-changed=${this.handlePersonaChanged}
+          @cached-models-changed=${this.handleCachedModelsChanged}
           ?disabled=${this.isLoadingModel || this.isGenerating}
         >
         </llm-options>
       </div>
     `;
+  }
+
+  private handleCachedModelsChanged(event: CustomEvent<Set<string>>) {
+    this.cachedModels = event.detail;
   }
 }

--- a/examples/llm_inference/llm_chat_ts/src/llm_options.ts
+++ b/examples/llm_inference/llm_chat_ts/src/llm_options.ts
@@ -232,6 +232,7 @@ export class LlmOptions extends LitElement {
     if (confirm('Remove model from cache?')) {
       await removeCachedModel(path);
       this.cachedModels = await getCachedModelsInfo();
+      this._dispatchCachedModelsChanged();
     }
   }
 
@@ -240,7 +241,17 @@ export class LlmOptions extends LitElement {
     if (confirm('Remove all models from cache?')) {
       await removeAllCachedModels();
       this.cachedModels = await getCachedModelsInfo();
+      this._dispatchCachedModelsChanged();
     }
+  }
+
+  private _dispatchCachedModelsChanged() {
+    const event = new CustomEvent('cached-models-changed', {
+      detail: this.cachedModels,
+      bubbles: true,
+      composed: true,
+    });
+    this.dispatchEvent(event);
   }
 
   private async handleLogin() {
@@ -412,5 +423,6 @@ declare global {
       LlmInferenceOptions & { forceF32?: boolean }
     >;
     'persona-changed': CustomEvent<Persona>;
+    'cached-models-changed': CustomEvent<Set<string>>;
   }
 }


### PR DESCRIPTION
### Description
Fixes the case when a model is removed from cache, but the user continues to use it while it's loaded. This works (and it should), but the UI incorrectly reverts to showing the model being cached and including it in size calculations. This patch fixes that issue.

Fixes # (issue)

### Checklist
Please ensure the following items are complete before submitting a pull request:

- [ ] My code follows the code style of the project.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added tests to cover my changes.

### Type of Change
Please check the relevant option below:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update (non-breaking change which updates documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots
If applicable, please add screenshots to help explain your changes.

### Additional Notes
Add any additional information or context about the pull request here.
