### PR TITLE
Fixed issue with `examples/llm_inference/js` failing to load larger models by implementing buffered loading system allowing for the loading of larger models like Gemma 3n E2B & E4B

### DIFF
--- a/examples/llm_inference/js/index.js
+++ b/examples/llm_inference/js/index.js
@@ -21,7 +21,7 @@ const output = document.getElementById('output');
 const submit = document.getElementById('submit');
 
 const modelFileName = 'gemma-2b-it-gpu-int4.bin'; /* Update the file name */
-//const modelFileName = 'https://huggingface.co/google/gemma-3n-E2B-it-litert-lm/resolve/main/gemma-3n-E2B-it-int4-Web.litertlm'; /* Update the file name */
+//const modelFileName = 'https://huggingface.co/google/gemma-3n-E2B-it-litert-lm/resolve/main/gemma-3n-E2B-it-int4-Web.litertlm'; /* Works with URLs as well! */
 
 /**
  * Gets the final part of a path whether URL or file directory


### PR DESCRIPTION
### Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

### Checklist
Please ensure the following items are complete before submitting a pull request:

- [x] My code follows the code style of the project.
- [x] I have updated the documentation (if applicable).
- [x] I have added tests to cover my changes.

### Type of Change
Please check the relevant option below:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update (non-breaking change which updates documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Additional Notes
Now capable of loading larger models (i.e. Google's E2B & E4B) without just completely crashing.
