### PR TITLE
Fix confidence_mask namespace and applicationId

### DIFF
--- a/examples/image_segmentation/android/confidence_mask/app/build.gradle
+++ b/examples/image_segmentation/android/confidence_mask/app/build.gradle
@@ -24,10 +24,10 @@ plugins {
 
 android {
     compileSdk 34
-    namespace "com.google.mediapipe.examples.imagesegmentation"
+    namespace "com.google.mediapipe.examples.imagesegmenter"
 
     defaultConfig {
-        applicationId "com.google.mediapipe.examples.imagesegmentation"
+        applicationId "com.google.mediapipe.examples.imagesegmenter"
         minSdk 26
         targetSdk 34
         versionCode 1


### PR DESCRIPTION
### Description

Fixes an Android build/runtime issue in the `confidence_mask` image segmentation sample.

The sample fails due to incorrect `namespace` and `applicationId` values in:

`examples/image_segmentation/android/confidence_mask/app/build.gradle`

### Changes

Updated:

* `namespace` → `com.google.mediapipe.examples.imagesegmenter`
* `applicationId` → `com.google.mediapipe.examples.imagesegmenter`

### Motivation / Context

Running the `confidence_mask` Android sample locally failed because of this mismatch.

Updating these values resolves the issue and allows the sample to build and run successfully.

Fixes #N/A

### Checklist

* [x] My code follows the code style of the project.
* [ ] I have updated the documentation (not applicable).
* [ ] I have added tests to cover my changes (not applicable).

### Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Documentation update (non-breaking change which updates documentation)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots

N/A

### Additional Notes

Verified locally by building and running:

`examples/image_segmentation/android/confidence_mask`
