### PR TITLE
Add git clone command and fix repo name directory path in README

### DIFF
--- a/examples/gesture_recognizer/raspberry_pi/README.md
+++ b/examples/gesture_recognizer/raspberry_pi/README.md
@@ -30,7 +30,8 @@ First, clone this Git repo onto your Raspberry Pi.
 Run this script to install the required dependencies and download the task file:
 
 ```
-cd mediapipe/examples/gesture_recognizer/raspberry_pi
+git clone https://github.com/google-ai-edge/mediapipe-samples.git
+cd mediapipe-samples/examples/gesture_recognizer/raspberry_pi
 sh setup.sh
 ```
 


### PR DESCRIPTION
### Description
The gesture recogniser raspberry pi example cd referenced the incorrect repo name, so I changed the directory from mediapipe to the correct mediapipe-samples. I added a git clone command so the user can easily clone the exact required repo.

Fixes # (issue)

### Checklist
Please ensure the following items are complete before submitting a pull request:

- [ ] My code follows the code style of the project.
- [ x ] I have updated the documentation (if applicable).
- [ ] I have added tests to cover my changes.

### Type of Change
Please check the relevant option below:

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x ] Documentation update (non-breaking change which updates documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots
If applicable, please add screenshots to help explain your changes.
Before:
<img width="1087" height="242" alt="Screenshot 2026-07-18 163851" src="https://github.com/user-attachments/assets/17abc561-39c6-478b-9068-530a8cfb1ef4" />
After:
<img width="1443" height="240" alt="Screenshot 2026-07-18 163756" src="https://github.com/user-attachments/assets/c17751aa-7567-4cf0-897e-60e30b02e13e" />


### Additional Notes
Add any additional information or context about the pull request here.
