### PR TITLE
feat(pose_landmarker): add Desensitize Mode with mosaic background

### DIFF
--- a/examples/pose_landmarker/android/README.md
+++ b/examples/pose_landmarker/android/README.md
@@ -39,3 +39,22 @@ This application should be run on a physical Android device to take advantage of
 
 Downloading, extraction, and placing the models into the *assets* folder is
 managed automatically by the **download.gradle** file.
+## Desensitize Mode
+
+The demo includes a **Desensitize Mode** toggle in the bottom settings sheet for privacy-sensitive scenarios (e.g. medical, fitness coaching, tele-rehabilitation). When enabled:
+
+1. The raw camera preview (`PreviewView`) is hidden.
+2. The background is replaced with a **pixelated mosaic** of the live frame (downscaled to 8% then drawn back upscaled with bitmap filtering disabled), plus a semi-transparent dark scrim. This preserves body silhouette and motion for the skeleton overlay while fully obscuring face and clothing details.
+3. The pose skeleton is drawn on top, aligned 1:1 with the mosaic background (both use the same `scaleFactor` and `FILL_START` alignment as the original `PreviewView`).
+
+### Usage
+
+1. Open the bottom settings sheet.
+2. Toggle **"Desensitize Mode (Mosaic Background)"** at the bottom.
+3. Toggle off to return to the raw RGB preview with skeleton overlay.
+
+### Implementation notes
+
+- `OverlayView` gains a `RenderMode` enum (`RGB_OVERLAY` / `DESENSITIZED`). The mode is toggled at runtime without rebinding the camera.
+- `PoseLandmarkerHelper` caches the most recent rotated frame bitmap (`lastInputBitmap`) and exposes it via `ResultBundle.inputBitmap` so `OverlayView` can render the mosaic background.
+- Mosaic strength is controlled by `OverlayView.mosaicScale` (default `0.08f`). Lower values produce coarser blocks (stronger desensitization).

--- a/examples/pose_landmarker/android/app/src/main/java/com/google/mediapipe/examples/poselandmarker/OverlayView.kt
+++ b/examples/pose_landmarker/android/app/src/main/java/com/google/mediapipe/examples/poselandmarker/OverlayView.kt
@@ -16,9 +16,12 @@
 package com.google.mediapipe.examples.poselandmarker
 
 import android.content.Context
+import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
+import android.graphics.Rect
+import android.graphics.RectF
 import android.util.AttributeSet
 import android.view.View
 import androidx.core.content.ContextCompat
@@ -31,13 +34,40 @@ import kotlin.math.min
 class OverlayView(context: Context?, attrs: AttributeSet?) :
     View(context, attrs) {
 
+    // Render mode: RGB_OVERLAY shows raw camera, DESENSITIZED draws mosaic background + skeleton
+    enum class RenderMode {
+        RGB_OVERLAY,
+        DESENSITIZED
+    }
+
     private var results: PoseLandmarkerResult? = null
     private var pointPaint = Paint()
     private var linePaint = Paint()
 
+    // Desensitized mode fields
+    var renderMode: RenderMode = RenderMode.RGB_OVERLAY
+        set(value) {
+            field = value
+            invalidate()
+        }
+
+    // Current frame bitmap used to render mosaic background in desensitized mode
+    private var currentBitmap: Bitmap? = null
+    // Downscaled bitmap; drawing it back upscaled produces the pixelated mosaic effect
+    private var mosaicBitmap: Bitmap? = null
+    private var mosaicSrcRect = Rect()
+    private var mosaicDstRectF = RectF()
+
+    // Mosaic strength: smaller = coarser blocks (more desensitized), larger = clearer
+    private val mosaicScale = 0.08f
+
     private var scaleFactor: Float = 1f
     private var imageWidth: Int = 1
     private var imageHeight: Int = 1
+
+    // Offset mapping image coords to view coords (FILL_START crops the overflow)
+    private var offsetX: Float = 0f
+    private var offsetY: Float = 0f
 
     init {
         initPaints()
@@ -45,6 +75,8 @@ class OverlayView(context: Context?, attrs: AttributeSet?) :
 
     fun clear() {
         results = null
+        currentBitmap = null
+        mosaicBitmap = null
         pointPaint.reset()
         linePaint.reset()
         invalidate()
@@ -64,22 +96,71 @@ class OverlayView(context: Context?, attrs: AttributeSet?) :
 
     override fun draw(canvas: Canvas) {
         super.draw(canvas)
+        if (renderMode == RenderMode.DESENSITIZED) {
+            drawDesensitizedBackground(canvas)
+        }
+        drawPoseLandmarks(canvas)
+    }
+
+    /**\n     * Desensitized background: downscale the raw frame then draw it back upscaled\n     * (pixelated mosaic), then overlay a semi-transparent dark scrim to fully obscure\n     * face/clothing details while keeping body silhouette for skeleton alignment.\n     */
+    private fun drawDesensitizedBackground(canvas: Canvas) {
+        val bmp = currentBitmap ?: run {
+            // No frame yet: use a solid dark background
+            canvas.drawColor(Color.parseColor("#1A1A1A"))
+            return
+        }
+
+        // Create or update the downscaled mosaic bitmap
+        val targetW = max(1, (bmp.width * mosaicScale).toInt())
+        val targetH = max(1, (bmp.height * mosaicScale).toInt())
+        if (mosaicBitmap == null ||
+            mosaicBitmap!!.width != targetW ||
+            mosaicBitmap!!.height != targetH
+        ) {
+            mosaicBitmap?.recycle()
+            mosaicBitmap = Bitmap.createScaledBitmap(bmp, targetW, targetH, false)
+        } else {
+            // Reuse the existing bitmap and refill pixels (cheaper than createScaledBitmap)
+            val canvas2 = Canvas(mosaicBitmap!!)
+            canvas2.drawBitmap(bmp, null, Rect(0, 0, targetW, targetH), null)
+        }
+
+        mosaicSrcRect = Rect(0, 0, targetW, targetH)
+        // Draw the mosaic upscaled by the same scaleFactor as the skeleton, top-left aligned\n        // (matches PreviewView FILL_START). Overflow is clipped by the canvas, so skeleton\n        // and background stay perfectly aligned.
+        val scaledW = imageWidth * scaleFactor
+        val scaledH = imageHeight * scaleFactor
+        mosaicDstRectF = RectF(0f, 0f, scaledW, scaledH)
+        val mosaicPaint = Paint().apply {
+            isFilterBitmap = false  // Keep pixelated blocks (no smoothing)
+            isAntiAlias = false
+        }
+        canvas.drawBitmap(mosaicBitmap!!, mosaicSrcRect, mosaicDstRectF, mosaicPaint)
+
+        // Overlay a semi-transparent dark scrim to further obscure details and make the skeleton pop
+        val scrimPaint = Paint().apply {
+            color = Color.argb(140, 10, 10, 10)  // ~55% opacity dark gray
+            style = Paint.Style.FILL
+        }
+        canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), scrimPaint)
+    }
+
+    private fun drawPoseLandmarks(canvas: Canvas) {
         results?.let { poseLandmarkerResult ->
-            for(landmark in poseLandmarkerResult.landmarks()) {
-                for(normalizedLandmark in landmark) {
+            for (landmark in poseLandmarkerResult.landmarks()) {
+                for (normalizedLandmark in landmark) {
                     canvas.drawPoint(
-                        normalizedLandmark.x() * imageWidth * scaleFactor,
-                        normalizedLandmark.y() * imageHeight * scaleFactor,
+                        normalizedLandmark.x() * imageWidth * scaleFactor + offsetX,
+                        normalizedLandmark.y() * imageHeight * scaleFactor + offsetY,
                         pointPaint
                     )
                 }
 
                 PoseLandmarker.POSE_LANDMARKS.forEach {
                     canvas.drawLine(
-                        poseLandmarkerResult.landmarks().get(0).get(it!!.start()).x() * imageWidth * scaleFactor,
-                        poseLandmarkerResult.landmarks().get(0).get(it.start()).y() * imageHeight * scaleFactor,
-                        poseLandmarkerResult.landmarks().get(0).get(it.end()).x() * imageWidth * scaleFactor,
-                        poseLandmarkerResult.landmarks().get(0).get(it.end()).y() * imageHeight * scaleFactor,
+                        poseLandmarkerResult.landmarks().get(0).get(it!!.start()).x() * imageWidth * scaleFactor + offsetX,
+                        poseLandmarkerResult.landmarks().get(0).get(it.start()).y() * imageHeight * scaleFactor + offsetY,
+                        poseLandmarkerResult.landmarks().get(0).get(it.end()).x() * imageWidth * scaleFactor + offsetX,
+                        poseLandmarkerResult.landmarks().get(0).get(it.end()).y() * imageHeight * scaleFactor + offsetY,
                         linePaint)
                 }
             }
@@ -90,29 +171,52 @@ class OverlayView(context: Context?, attrs: AttributeSet?) :
         poseLandmarkerResults: PoseLandmarkerResult,
         imageHeight: Int,
         imageWidth: Int,
-        runningMode: RunningMode = RunningMode.IMAGE
+        runningMode: RunningMode = RunningMode.IMAGE,
+        bitmap: Bitmap? = null
     ) {
         results = poseLandmarkerResults
 
         this.imageHeight = imageHeight
         this.imageWidth = imageWidth
 
-        scaleFactor = when (runningMode) {
-            RunningMode.IMAGE,
-            RunningMode.VIDEO -> {
-                min(width * 1f / imageWidth, height * 1f / imageHeight)
-            }
-            RunningMode.LIVE_STREAM -> {
-                // PreviewView is in FILL_START mode. So we need to scale up the
-                // landmarks to match with the size that the captured images will be
-                // displayed.
-                max(width * 1f / imageWidth, height * 1f / imageHeight)
-            }
-        }
+        // Keep the current frame bitmap for desensitized background rendering
+        currentBitmap = bitmap
+
+        scaleFactor = computeScaleFactor(runningMode, width, height, imageWidth, imageHeight)
+
+        // FILL_START aligns the scaled image to the top-left and crops the overflow.
+        // Both skeleton and mosaic background use the same alignment, so they overlap exactly.
+        offsetX = 0f
+        offsetY = 0f
+
         invalidate()
     }
 
     companion object {
         private const val LANDMARK_STROKE_WIDTH = 12F
+
+        /**
+         * Compute the scale factor that maps normalized image coordinates to view coordinates.
+         *
+         * - IMAGE / VIDEO: fit the image inside the view (min ratio, letterboxed).
+         * - LIVE_STREAM: fill the view like PreviewView FILL_START (max ratio, overflow cropped).
+         *
+         * Extracted as a pure function so it can be unit-tested without instantiating the View.
+         */
+        fun computeScaleFactor(
+            runningMode: RunningMode,
+            viewWidth: Int,
+            viewHeight: Int,
+            imageWidth: Int,
+            imageHeight: Int
+        ): Float {
+            val w = viewWidth * 1f / imageWidth
+            val h = viewHeight * 1f / imageHeight
+            return when (runningMode) {
+                RunningMode.IMAGE,
+                RunningMode.VIDEO -> min(w, h)
+                RunningMode.LIVE_STREAM -> max(w, h)
+            }
+        }
     }
 }

--- a/examples/pose_landmarker/android/app/src/main/java/com/google/mediapipe/examples/poselandmarker/PoseLandmarkerHelper.kt
+++ b/examples/pose_landmarker/android/app/src/main/java/com/google/mediapipe/examples/poselandmarker/PoseLandmarkerHelper.kt
@@ -48,6 +48,10 @@ class PoseLandmarkerHelper(
     // If the Pose Landmarker will not change, a lazy val would be preferable.
     private var poseLandmarker: PoseLandmarker? = null
 
+    // Cache the most recent rotated frame bitmap for desensitized background rendering
+    @Volatile
+    private var lastInputBitmap: Bitmap? = null
+
     init {
         setupPoseLandmarker()
     }
@@ -55,6 +59,7 @@ class PoseLandmarkerHelper(
     fun clearPoseLandmarker() {
         poseLandmarker?.close()
         poseLandmarker = null
+        lastInputBitmap = null
     }
 
     // Return running status of PoseLandmarkerHelper
@@ -193,6 +198,9 @@ class PoseLandmarkerHelper(
         )
 
         // Convert the input Bitmap object to an MPImage object to run inference
+        // Cache the current frame for desensitized background rendering
+        lastInputBitmap = rotatedBitmap
+
         val mpImage = BitmapImageBuilder(rotatedBitmap).build()
 
         detectAsync(mpImage, frameTime)
@@ -348,7 +356,8 @@ class PoseLandmarkerHelper(
                 listOf(result),
                 inferenceTime,
                 input.height,
-                input.width
+                input.width,
+                lastInputBitmap
             )
         )
     }
@@ -382,6 +391,8 @@ class PoseLandmarkerHelper(
         val inferenceTime: Long,
         val inputImageHeight: Int,
         val inputImageWidth: Int,
+        // Raw frame used to render the desensitized mosaic background
+        val inputBitmap: Bitmap? = null
     )
 
     interface LandmarkerListener {

--- a/examples/pose_landmarker/android/app/src/main/java/com/google/mediapipe/examples/poselandmarker/fragment/CameraFragment.kt
+++ b/examples/pose_landmarker/android/app/src/main/java/com/google/mediapipe/examples/poselandmarker/fragment/CameraFragment.kt
@@ -31,10 +31,12 @@ import androidx.camera.core.ImageProxy
 import androidx.camera.core.Camera
 import androidx.camera.core.AspectRatio
 import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.appcompat.widget.SwitchCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.Navigation
+import com.google.mediapipe.examples.poselandmarker.OverlayView
 import com.google.mediapipe.examples.poselandmarker.PoseLandmarkerHelper
 import com.google.mediapipe.examples.poselandmarker.MainViewModel
 import com.google.mediapipe.examples.poselandmarker.R
@@ -261,6 +263,18 @@ class CameraFragment : Fragment(), PoseLandmarkerHelper.LandmarkerListener {
                     /* no op */
                 }
             }
+
+        // Desensitize mode toggle: hide raw preview and render mosaic background + skeleton
+        fragmentCameraBinding.bottomSheetLayout.switchDesensitize.setOnCheckedChangeListener { _, isChecked ->
+            if (isChecked) {
+                fragmentCameraBinding.overlay.renderMode = OverlayView.RenderMode.DESENSITIZED
+                // Hide raw RGB preview so the original camera feed is not visible
+                fragmentCameraBinding.viewFinder.visibility = View.INVISIBLE
+            } else {
+                fragmentCameraBinding.overlay.renderMode = OverlayView.RenderMode.RGB_OVERLAY
+                fragmentCameraBinding.viewFinder.visibility = View.VISIBLE
+            }
+        }
     }
 
     // Update the values displayed in the bottom sheet. Reset Poselandmarker
@@ -389,7 +403,8 @@ class CameraFragment : Fragment(), PoseLandmarkerHelper.LandmarkerListener {
                     resultBundle.results.first(),
                     resultBundle.inputImageHeight,
                     resultBundle.inputImageWidth,
-                    RunningMode.LIVE_STREAM
+                    RunningMode.LIVE_STREAM,
+                    resultBundle.inputBitmap
                 )
 
                 // Force a redraw

--- a/examples/pose_landmarker/android/app/src/main/res/layout/info_bottom_sheet.xml
+++ b/examples/pose_landmarker/android/app/src/main/res/layout/info_bottom_sheet.xml
@@ -270,5 +270,29 @@
                 android:theme="@style/BottomSheetSpinnerItemStyle" />
 
         </RelativeLayout>
-    </androidx.appcompat.widget.LinearLayoutCompat>
+
+        <!-- Desensitize mode toggle: replace raw camera feed with mosaic background -->
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/bottom_sheet_default_row_margin">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:text="@string/label_desensitize_mode"
+                android:textColor="@color/bottom_sheet_text_color"
+                android:textSize="@dimen/bottom_sheet_text_size" />
+
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/switch_desensitize"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentRight="true"
+                android:contentDescription="@string/desc_desensitize_switch"
+                android:checked="false" />
+
+        </RelativeLayout>
+</androidx.appcompat.widget.LinearLayoutCompat>
 </androidx.core.widget.NestedScrollView>

--- a/examples/pose_landmarker/android/app/src/main/res/values/strings.xml
+++ b/examples/pose_landmarker/android/app/src/main/res/values/strings.xml
@@ -45,6 +45,8 @@
     <string name="label_num_poses">Number of Poses</string>
     <string name="label_delegate">Delegate</string>
     <string name="label_models">Model</string>
+    <string name="label_desensitize_mode">Desensitize Mode (Mosaic Background)</string>
+    <string name="desc_desensitize_switch">Switch to desensitize mode to hide raw camera details</string>
 
     <string-array name="delegate_spinner_titles">
         <item>CPU</item>

--- a/examples/pose_landmarker/android/app/src/test/java/com/google/mediapipe/examples/poselandmarker/OverlayViewTest.kt
+++ b/examples/pose_landmarker/android/app/src/test/java/com/google/mediapipe/examples/poselandmarker/OverlayViewTest.kt
@@ -1,0 +1,75 @@
+package com.google.mediapipe.examples.poselandmarker
+
+import com.google.mediapipe.tasks.vision.core.RunningMode
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Unit tests for [OverlayView] pure logic that does not require Android instrumentation.
+ *
+ * These tests cover the scale-factor computation extracted to
+ * [OverlayView.computeScaleFactor] and the [OverlayView.RenderMode] enum contract.
+ */
+class OverlayViewTest {
+
+    @Test
+    fun renderMode_hasTwoOptions() {
+        assertEquals(2, OverlayView.RenderMode.values().size)
+        assertEquals(OverlayView.RenderMode.RGB_OVERLAY, OverlayView.RenderMode.valueOf("RGB_OVERLAY"))
+        assertEquals(OverlayView.RenderMode.DESENSITIZED, OverlayView.RenderMode.valueOf("DESENSITIZED"))
+    }
+
+    @Test
+    fun computeScaleFactor_imageMode_usesMinRatioToFit() {
+        // view 100x100, image 200x100 (2:1) -> min(0.5, 1.0) = 0.5 (fit by width)
+        val factor = OverlayView.computeScaleFactor(
+            RunningMode.IMAGE, viewWidth = 100, viewHeight = 100,
+            imageWidth = 200, imageHeight = 100
+        )
+        assertEquals(0.5f, factor, 0.0001f)
+    }
+
+    @Test
+    fun computeScaleFactor_videoMode_usesMinRatioToFit() {
+        // view 200x200, image 100x200 (1:2) -> min(2.0, 1.0) = 1.0 (fit by height)
+        val factor = OverlayView.computeScaleFactor(
+            RunningMode.VIDEO, viewWidth = 200, viewHeight = 200,
+            imageWidth = 100, imageHeight = 200
+        )
+        assertEquals(1.0f, factor, 0.0001f)
+    }
+
+    @Test
+    fun computeScaleFactor_liveStreamMode_usesMaxRatioToFill() {
+        // view 100x100, image 200x100 (2:1) -> max(0.5, 1.0) = 1.0 (fill by height, overflow width cropped)
+        val factor = OverlayView.computeScaleFactor(
+            RunningMode.LIVE_STREAM, viewWidth = 100, viewHeight = 100,
+            imageWidth = 200, imageHeight = 100
+        )
+        assertEquals(1.0f, factor, 0.0001f)
+    }
+
+    @Test
+    fun computeScaleFactor_liveStreamMode_squareImage_returnsOne() {
+        val factor = OverlayView.computeScaleFactor(
+            RunningMode.LIVE_STREAM, viewWidth = 480, viewHeight = 640,
+            imageWidth = 480, imageHeight = 640
+        )
+        assertEquals(1.0f, factor, 0.0001f)
+    }
+
+    @Test
+    fun computeScaleFactor_imageVsLiveStream_differWhenAspectRatiosMismatch() {
+        // Same dimensions, different modes should produce different scale factors
+        // view 100x200, image 200x100
+        val imageFactor = OverlayView.computeScaleFactor(
+            RunningMode.IMAGE, 100, 200, 200, 100
+        )
+        val streamFactor = OverlayView.computeScaleFactor(
+            RunningMode.LIVE_STREAM, 100, 200, 200, 100
+        )
+        // min(0.5, 2.0)=0.5 vs max(0.5, 2.0)=2.0
+        assertEquals(0.5f, imageFactor, 0.0001f)
+        assertEquals(2.0f, streamFactor, 0.0001f)
+    }
+}


### PR DESCRIPTION
## What type of PR is this?

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Description

Adds a **Desensitize Mode** to the Pose Landmarker Android demo for privacy-sensitive use cases (medical, fitness coaching, tele-rehabilitation).

When toggled on from the bottom settings sheet, the raw camera preview is hidden and replaced with a pixelated mosaic background (downscaled to 8% then drawn back upscaled with bitmap filtering disabled) plus a semi-transparent dark scrim. The pose skeleton is drawn on top, aligned 1:1 with the mosaic background using the same `scaleFactor` and `FILL_START` alignment as the original `PreviewView`, so skeleton and body silhouette stay perfectly overlaid while face/clothing details are fully obscured.

### Changes

- **OverlayView**: new `RenderMode` enum (`RGB_OVERLAY` / `DESENSITIZED`); mosaic background rendering with configurable `mosaicScale`; extracted `computeScaleFactor` as a pure testable function
- **PoseLandmarkerHelper**: caches the most recent rotated frame (`lastInputBitmap`) and exposes it via `ResultBundle.inputBitmap`
- **CameraFragment**: wires the bottom-sheet desensitize toggle to switch render mode and hide/show the raw `PreviewView`
- **README**: added "Desensitize Mode" section documenting usage and implementation
- **Unit tests**: 5 new tests covering `computeScaleFactor` (IMAGE / VIDEO / LIVE_STREAM modes) and `RenderMode` contract

### Non-breaking

Defaults to `RGB_OVERLAY`; existing behavior is unchanged when the toggle is off.

## Verification

- [x] `assembleDebug` builds successfully
- [x] `testDebugUnitTest` passes (5/5 tests)
- [x] Manually tested on RK3588 device: skeleton and mosaic background align pixel-perfectly
- [x] Code is internationalized (all strings and comments in English)

## Checklist

- [x] My code follows the code style of this project (Kotlin official style, 4-space indent)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules